### PR TITLE
Add documentation URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "spaceapi"
 version = "0.1.0"
+documentation = "https://coredump-ch.github.io/rust-docs/spaceapi/spaceapi/index.html"
 repository = "https://github.com/coredump-ch/spaceapi-rs/"
 license = "MIT"
 authors = [

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This is an implementation of the [SpaceAPI](http://spaceapi.net/) v0.13 in
 Rust. It contains both the type definitions as well as tools for serialization
 and deserialization.
 
-Space API Documentation: http://spaceapi.net/documentation
+- Crate Documentation: https://coredump-ch.github.io/rust-docs/spaceapi/spaceapi/index.html
+- Space API Documentation: http://spaceapi.net/documentation
 
 
 ## Usage


### PR DESCRIPTION
I managed to set up docs generation through Travis in 4c9f15261352d6943980493d60886f74805e4db3.

This PR adds the documentation link to README and crate description.