### PR TITLE
Changelog + Version Bump to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+This project follows semantic versioning.
+
+Possible log types:
+
+- `[added]` for new features.
+- `[changed]` for changes in existing functionality.
+- `[deprecated]` for once-stable features removed in upcoming releases.
+- `[removed]` for deprecated features removed in this release.
+- `[fixed]` for any bug fixes.
+- `[security]` to invite users to upgrade in case of vulnerabilities.
+
+
+### UNRELEASED
+
+- ...
+
+### v0.2.0 (2015-11-23)
+
+- [added] Support for deserialization (#12)
+- [changed] Improved docs (#10)
+- [changed] Performance improvements (#11)
+
+### v0.1.1 (2015-11-16)
+
+- [fixed] Fixed documentation URL in `Cargo.toml`
+
+### v0.1.0 (2015-11-14)
+
+- First crates.io release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spaceapi"
-version = "0.1.1"
+version = "0.2.0"
 documentation = "https://coredump-ch.github.io/rust-docs/spaceapi/spaceapi/index.html"
 repository = "https://github.com/coredump-ch/spaceapi-rs/"
 license = "MIT"


### PR DESCRIPTION
Fixes #13.

- Added CHANGELOG
- Bumped version

After this is merged we can release.