### PR TITLE
Version information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Possible log types:
 ### v0.3.1 (UNRELEASED)
 
 - [added] Top level `get_version` function (#31)
+- [added] Added `Status::ext_versions` field (#31)
 - ...
 
 ### v0.3.0 (2016-06-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
-### UNRELEASED
+### v0.3.1 (UNRELEASED)
 
+- [added] Top level `get_version` function (#31)
 - ...
 
 ### v0.3.0 (2016-06-25)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spaceapi"
-version = "0.3.0"
+version = "0.3.1"
 documentation = "https://coredump-ch.github.io/rust-docs/spaceapi/spaceapi/index.html"
 repository = "https://github.com/coredump-ch/spaceapi-rs/"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,3 +90,19 @@ pub mod optional;
 pub mod sensors;
 mod status;
 pub use status::*;
+
+/// Return own crate version. Used in API responses.
+pub fn get_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[cfg(test)]
+mod test {
+    use super::get_version;
+
+    #[test]
+    fn test_get_version() {
+        let version = get_version();
+        assert_eq!(3, version.split('.').count());
+    }
+}

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use rustc_serialize::json::{Json, ToJson};
 pub use optional::Optional;
 pub use sensors::SensorTemplate;
@@ -130,6 +130,11 @@ pub struct Status {
     // Mutable data
     pub state: State,
     pub sensors: Optional<Sensors>,
+
+    // Version extension
+    // TODO: Once we move to serde, maybe we can store this
+    // as `HashMap<String, &'static str>`?
+    pub ext_versions: Optional<HashMap<String, String>>,
 }
 
 impl Status {
@@ -162,6 +167,8 @@ impl Status {
                 icon: Optional::Absent,
             },
             sensors: Optional::Absent,
+
+            ext_versions: Optional::Absent,
         }
     }
 
@@ -190,6 +197,10 @@ impl ToJson for Status {
 
         d.insert("state".into(), self.state.to_json());
         self.sensors.as_ref().map_or((), |v| { d.insert("sensors".into(), v.to_json()); });
+
+        if let Optional::Value(ref versions) = self.ext_versions {
+            d.insert("ext_versions".into(), versions.to_json());
+        }
 
         Json::Object(d)
     }


### PR DESCRIPTION
See https://github.com/coredump-ch/spaceapi-server-rs/issues/4.

This adds a `get_version()` function on top level, as well as adding the `ext_versions` field to the `Status` struct.