### PR TITLE
Fix unneeded attribute warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,6 @@
 //!     // Location { address: None, lat: 47.22936000000001, lon: 8.829490000000002 }
 //!     # }
 
-#![feature(proc_macro)]
-
 #[macro_use]
 extern crate log;
 extern crate serde;


### PR DESCRIPTION
```
warning: this feature has been stable since 1.15.0. Attribute no longer needed, #[warn(stable_features)] on by default
  --> src/lib.rs:74:12
   |
74 | #![feature(proc_macro)]
   |            ^^^^^^^^^^
```