### PR TITLE
Fix bug in Status serializer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,10 @@
 //!         .add_issue_report_channel("twitter")
 //!         .build()
 //!         .expect("Creating status failed");
-//!     let stringstatus = serde_json::to_string(&status).unwrap();
-//!     let jsonstatus: Status = serde_json::from_str(&stringstatus).unwrap();
+//!     let serialized = serde_json::to_string(&status).unwrap();
+//!     let deserialized: Status = serde_json::from_str(&serialized).unwrap();
 //!
-//!     # assert!(&stringstatus[0..1] == "{");
+//!     # assert!(&serialized[0..1] == "{");
 //!     # }
 //!
 //! ## Deserializing

--- a/src/status.rs
+++ b/src/status.rs
@@ -216,7 +216,7 @@ impl Serialize for Status {
             };
         }
         serialize!(self.api, "api");
-        serialize!(self.api, "space");
+        serialize!(self.space, "space");
         serialize!(self.logo, "logo");
         serialize!(self.url, "url");
         serialize!(self.location, "location");
@@ -484,8 +484,12 @@ mod test {
             .url("foobar")
             .location(Location::default())
             .contact(Contact::default())
-            .build();
-        assert!(status.is_ok());
+            .build()
+            .unwrap();
+        assert_eq!(status.api, "0.13");
+        assert_eq!(status.space, "foo");
+        assert_eq!(status.logo, "bar");
+        assert_eq!(status.url, "foobar");
     }
 
     #[test]
@@ -502,6 +506,20 @@ mod test {
             "{\"_type\":\"rss\",\"url\":\"https://some/rss.xml\"}".to_string());
         assert_eq!(to_string(&f2).unwrap(),
             "{\"url\":\"https://some/rss.xml\"}".to_string());
+    }
+
+    #[test]
+    fn serialize_deserialize_full() {
+        let status = StatusBuilder::new("foo")
+            .logo("bar")
+            .url("foobar")
+            .location(Location::default())
+            .contact(Contact::default())
+            .build()
+            .unwrap();
+        let serialized = to_string(&status).unwrap();
+        let deserialized = from_str::<Status>(&serialized).unwrap();
+        assert_eq!(status, deserialized);
     }
 
 }


### PR DESCRIPTION
Instead of the space name, the version was emitted a second time.
Embarassing bug that happened due to low test coverage:

> $ cargo run --example serialization
> {"api":"0.13","space":"0.13","logo":"https://...

I fixed the bug and added a round-trip-serialization test that should
catch bugs like these in the future.

@rnestler @dns2utf8 want to review?