### PR TITLE
Use get_or_insert to add values to Option<Vec> fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.15.0
+  - 1.20.0
   - stable
   - beta
   - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Possible log types:
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+### Unreleased
+
+- [changed] Minimal required Rust version 1.20.0 (#68)
+
 ### v0.5.1 (2017-06-17)
 
 - [fixed] Fix compilation warning (#65)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ serialization and deserialization to/from JSON using Serde.
 - Crate Documentation: https://docs.rs/spaceapi/
 - Space API Documentation: http://spaceapi.net/documentation
 
-This library requires Rust 1.15 or newer.
+This library requires Rust 1.20.0 or newer.
 
 
 ## Usage

--- a/src/status.rs
+++ b/src/status.rs
@@ -476,20 +476,12 @@ impl StatusBuilder {
     }
 
     pub fn add_event(mut self, event: Event) -> Self {
-        if let Some(ref mut events) = self.events {
-            events.push(event);
-        } else {
-            self.events = Some(vec![event]);
-        }
+        self.events.get_or_insert(vec![]).push(event);
         self
     }
 
     pub fn add_cam<S: Into<String>>(mut self, cam: S) -> Self {
-        if let Some(ref mut cams) = self.cam {
-            cams.push(cam.into());
-        } else {
-            self.cam = Some(vec![cam.into()]);
-        }
+        self.cam.get_or_insert(vec![]).push(cam.into());
         self
     }
 
@@ -499,20 +491,12 @@ impl StatusBuilder {
     }
 
     pub fn add_radio_show(mut self, radio_show: RadioShow) -> Self {
-        if let Some(ref mut radio_shows) = self.radio_show {
-            radio_shows.push(radio_show);
-        } else {
-            self.radio_show = Some(vec![radio_show]);
-        }
+        self.radio_show.get_or_insert(vec![]).push(radio_show);
         self
     }
 
     pub fn add_project<S: Into<String>>(mut self, project: S) -> Self {
-        if let Some(ref mut projects) = self.projects {
-            projects.push(project.into());
-        } else {
-            self.projects = Some(vec![project.into()]);
-        }
+        self.projects.get_or_insert(vec![]).push(project.into());
         self
     }
 


### PR DESCRIPTION
This method was added in Rust 1.20.0. See:
https://doc.rust-lang.org/std/option/enum.Option.html#method.get_or_insert

It simplifies the code a lot.

<!--- Explain your issue / bug / feature -->

## Checklist

- [x] Tests added if applicable
- [x] README updated if applicable
- [x] CHANGELOG updated if applicable
- [x] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
